### PR TITLE
SCRUM-186: Employee desk orders - confirm orders

### DIFF
--- a/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeSteps.java
+++ b/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeSteps.java
@@ -49,7 +49,7 @@ public class DeskOrdersEmployeeSteps {
 
   static void setupOrderAndEmployee(RestTemplate restTemplate) throws Exception {
     String jwt = createDeskOrdersEmployee(restTemplate);
-    long orderId = createOrder(restTemplate, jwt);
+    long orderId = createOrder(restTemplate);
     updateOrderToReady(orderId, jwt);
   }
 

--- a/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeSteps.java
+++ b/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeSteps.java
@@ -155,7 +155,7 @@ public class DeskOrdersEmployeeSteps {
   public static void setup() throws Exception {
     WebDriverManager.firefoxdriver().setup();
     FirefoxOptions options = new FirefoxOptions();
-    //options.addArguments("--headless");
+    options.addArguments("--headless");
     options.addArguments("--no-sandbox");
     options.addArguments("--disable-dev-shm-usage");
     driver = new FirefoxDriver(options);

--- a/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeSteps.java
+++ b/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeSteps.java
@@ -73,7 +73,7 @@ public class DeskOrdersEmployeeSteps {
     return res.getToken();
   }
 
-  static long createOrder(RestTemplate restTemplate, String jwt) throws Exception {
+  static long createOrder(RestTemplate restTemplate) throws Exception {
     String orderRequest =
         "{"
             + "    \"kioskId\": 1,"

--- a/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeSteps.java
+++ b/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeSteps.java
@@ -1,0 +1,225 @@
+package pt.ua.deti.springcanteen.frontend.employee_desk_orders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pt.ua.deti.springcanteen.integration.WebsocketUtils.connectAsyncWithHeaders;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Wait;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import io.cucumber.java.BeforeAll;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.github.bonigarcia.wdm.WebDriverManager;
+import pt.ua.deti.springcanteen.dto.JwtAuthenticationResponseDTO;
+import pt.ua.deti.springcanteen.dto.OrderUpdateRequestDTO;
+import pt.ua.deti.springcanteen.dto.response.clientresponse.OrderClientResponseDTO;
+
+public class DeskOrdersEmployeeSteps {
+  private static WebDriver driver;
+  private static JavascriptExecutor js;
+  private static Wait<WebDriver> wait;
+  private static Logger logger = LoggerFactory.getLogger(DeskOrdersEmployeeSteps.class);
+  private static final String BASE_BACKEND_URL = "localhost";
+
+  static void setupOrderAndEmployee(RestTemplate restTemplate) throws Exception {
+    String jwt = createDeskOrdersEmployee(restTemplate);
+    long orderId = createOrder(restTemplate, jwt);
+    updateOrderToReady(orderId, jwt);
+  }
+
+  // POST request to /api/auth/signup to create a desk orders employee
+  static String createDeskOrdersEmployee(RestTemplate restTemplate) {
+    String postData =
+        "{ \"username\": \"deskorders123\", \"password\": \"deskorders123\", \"email\":"
+            + " \"testdeskorders@gmail.com\", \"role\": \"DESK_ORDERS\"}";
+    String url = String.format("http://%s/api/auth/signup", BASE_BACKEND_URL);
+    logger.info("Calling {} to create user...", url);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    HttpEntity<String> request = new HttpEntity<>(postData, headers);
+    logger.info("{}", postData);
+    JwtAuthenticationResponseDTO res = restTemplate.postForEntity(url, request, JwtAuthenticationResponseDTO.class).getBody();
+    logger.info(
+        "Successfully created a cook employee with credentials: email - testdeskorders@gmail.com;"
+            + " password - deskorders123");
+    return res.getToken();
+  }
+
+  static long createOrder(RestTemplate restTemplate, String jwt) throws Exception {
+    String orderRequest =
+        "{"
+            + "    \"kioskId\": 1,"
+            + "    \"isPaid\": true,"
+            + "    \"isPriority\": true,"
+            + "    \"nif\": \"123456789\","
+            + "    \"orderMenus\": ["
+            + "        {"
+            + "            \"menuId\": 1,"
+            + "            \"customization\": {"
+            + "                \"customizedDrink\": {"
+            + "                    \"itemId\": 8"
+            + "                },"
+            + "                \"customizedMainDish\": {"
+            + "                    \"itemId\": 1,"
+            + "                    \"customizedIngredients\": ["
+            + "                        {"
+            + "                            \"ingredientId\": 1,"
+            + "                            \"quantity\": 1"
+            + "                        },"
+            + "                        {"
+            + "                            \"ingredientId\": 3,"
+            + "                            \"quantity\": 2"
+            + "                        },"
+            + "                        {"
+            + "                            \"ingredientId\": 4,"
+            + "                            \"quantity\": 2"
+            + "                        }"
+            + "                    ]"
+            + "                }"
+            + "            }"
+            + "        }"
+            + "    ]"
+            + "}";
+
+    String url = String.format("http://%s/api/orders", BASE_BACKEND_URL);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    HttpEntity<String> request = new HttpEntity<>(orderRequest, headers);
+
+    logger.info("Calling {} to create order...", url);
+    OrderClientResponseDTO response = restTemplate.postForEntity(url, request, OrderClientResponseDTO.class).getBody();
+    logger.info("Successfully created a paid priority order...");
+    return response.getId();
+  }
+
+  static void updateOrderToReady(long orderId, String jwt) throws InterruptedException, ExecutionException, TimeoutException {
+
+    WebSocketClient client = new StandardWebSocketClient();
+    WebSocketStompClient stompClient = new WebSocketStompClient(client);
+    stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+    String url = String.format("ws://%s/websocket", BASE_BACKEND_URL);
+    logger.info("Updating order status to READY...");
+
+    StompSessionHandlerAdapter sessionHandler = new StompSessionHandlerAdapter() {
+        @Override
+        public void afterConnected(StompSession session, StompHeaders connectedHeaders) {
+          OrderUpdateRequestDTO payload = new OrderUpdateRequestDTO();
+          payload.setOrderId(orderId);
+          logger.info("Sending payload: {}", payload);
+          session.send("/app/order_updates", payload);
+          session.send("/app/order_updates", payload);
+          logger.info("Payload for updating orders sent...");
+        }
+    };
+
+    StompHeaders stompHeaders = new StompHeaders();
+    stompHeaders.set("Authorization", "Bearer " + jwt);
+
+    connectAsyncWithHeaders(url, stompClient, stompHeaders);
+    stompClient.connectAsync(url, sessionHandler).get(10, TimeUnit.SECONDS);
+
+  }
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    WebDriverManager.firefoxdriver().setup();
+    FirefoxOptions options = new FirefoxOptions();
+    //options.addArguments("--headless");
+    options.addArguments("--no-sandbox");
+    options.addArguments("--disable-dev-shm-usage");
+    driver = new FirefoxDriver(options);
+    js = (JavascriptExecutor) driver;
+    // wait up to 10 seconds
+    driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
+    // setup wait
+    wait = new WebDriverWait(driver, Duration.ofSeconds(3));
+
+    RestTemplate restTemplate = new RestTemplate();
+    setupOrderAndEmployee(restTemplate);
+  }
+
+  
+
+  @Given("I have a clean local storage")
+  public void i_have_a_clean_local_storage() {
+    driver.get("http://localhost/");
+    js.executeScript("window.localStorage.clear()");
+  }
+
+  @And("I navigate to the sign in page")
+  public void i_navigate_to_the_sign_in_page() {
+    driver.get("http://localhost/signin");
+  }
+
+  @When("I submit username and password")
+  public void i_submit_username_and_password() {
+    driver.findElement(By.id("email")).sendKeys("testdeskorders@gmail.com");
+    driver.findElement(By.id("password")).sendKeys("deskorders123");
+  }
+
+  @And("I click the sign in button")
+  public void i_click_the_sign_in_button() {
+    driver.findElement(By.id("signin-button")).click();
+  }
+
+  @Then("I should be logged in")
+  public void i_should_be_logged_in() {
+    String actualPageText = driver.findElement(By.id("welcome-back-text")).getText();
+    assertThat(actualPageText).isEqualTo("Welcome back, deskorders123, get back to confirming ready orders,");
+  }
+
+  @When("I navigate to the ready orders page")
+  public void i_navigate_to_the_ready_orders_page() {
+    driver.get("http://localhost/employee/ready_orders");
+  }
+
+  @Then("I should see the single existing priority ready order")
+  public void i_should_see_the_single_existing_priority_ready_order() {
+    assertThat(driver.findElement(By.id("priority-ready-order-1")).isDisplayed()).isTrue();
+  }
+
+  @And("I click the Confirm pick up button for the first ready order")
+  public void i_click_the_confirm_pick_up_button_for_the_first_ready_order() {
+    driver.findElement(By.id("priority-ready-button-1")).click();
+  }
+
+  @Then("I should see the confirmation snackbar")
+  public void i_should_see_the_confirmation_snackbar() {
+    wait.until(
+        ExpectedConditions.visibilityOfElementLocated(By.xpath("//*[@id=\"notistack-snackbar\"]")));
+    assertThat(driver.findElement(By.xpath("//*[@id=\"notistack-snackbar\"]")).isDisplayed())
+        .isTrue();  
+  }
+
+}

--- a/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeTest.java
+++ b/backend/springcanteen/src/test/java/pt/ua/deti/springcanteen/frontend/employee_desk_orders/DeskOrdersEmployeeTest.java
@@ -1,0 +1,18 @@
+package pt.ua.deti.springcanteen.frontend.employee_desk_orders;
+
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("pt/ua/deti/springcanteen/frontend/employee_desk_orders")
+@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
+@ConfigurationParameter(
+    key = GLUE_PROPERTY_NAME,
+    value = "pt.ua.deti.springcanteen.frontend.employee_desk_orders")
+public class DeskOrdersEmployeeTest {}

--- a/backend/springcanteen/src/test/resources/pt/ua/deti/springcanteen/frontend/employee_desk_orders/desk_orders.feature
+++ b/backend/springcanteen/src/test/resources/pt/ua/deti/springcanteen/frontend/employee_desk_orders/desk_orders.feature
@@ -1,0 +1,20 @@
+@employee_desk_orders
+Feature: Operations that a "Desk orders" employee can perform
+    
+    Background: Desk orders employee is Logged In
+        Given I have a clean local storage
+        And I navigate to the sign in page
+        When I submit username and password
+        And I click the sign in button
+        Then I should be logged in 
+    
+    @view_ready_to_pick_up_orders
+    Scenario: Desk orders employee wants to see orders ready to pick up
+        When I navigate to the ready orders page
+        Then I should see the single existing priority ready order
+
+    @confirm_ready_to_pick_up_order
+    Scenario: Desk orders employee wants to confirm an order that is ready to pick up
+        When I navigate to the ready orders page
+        And I click the Confirm pick up button for the first ready order
+        Then I should see the confirmation snackbar

--- a/frontend/SpringKiosk/material-ui-vite-ts/src/components/employee_ready_orders_page/OrderReadyCard.tsx
+++ b/frontend/SpringKiosk/material-ui-vite-ts/src/components/employee_ready_orders_page/OrderReadyCard.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, CardActions, CardContent, Paper, Typography } from "@mui/material";
+import { Button, Card, CardActions, CardContent, Typography } from "@mui/material";
 import { CookOrder } from "../../types/OrderTypes";
 
 interface OrderReadyCardProps {
@@ -9,9 +9,6 @@ const OrderReadyCard = ({order}: OrderReadyCardProps) => {
     return (
         <Card sx={{ minWidth: 275 }}>
             <CardContent>
-                <Paper sx={{ padding: 1, backgroundColor: 'darkgreen', color: 'white', borderRadius: 1, textAlign: 'center', marginBottom: 2 }}>
-                    PRIORITY
-                </Paper>
                 <Typography sx={{ fontSize: 30, fontWeight: 'bold' }} color="text.secondary" gutterBottom>        
                     ORDER: {order.id}
                 </Typography>
@@ -23,6 +20,19 @@ const OrderReadyCard = ({order}: OrderReadyCardProps) => {
                 <Button size="small" color="primary">
                     Confirm Pick Up
                 </Button>
+                {order.priority && (
+                    <Typography ml={"auto"} mr={0} pr={1}
+                        sx={{
+                            fontWeight: "bold",
+                            background: 'linear-gradient(to top, darkgreen, green)',
+                            WebkitBackgroundClip: 'text',
+                            WebkitTextFillColor: 'transparent',
+                        }}
+                    >
+                        PRIORITY
+                    </Typography>
+                )}
+                
             </CardActions>
         </Card>
     )

--- a/frontend/SpringKiosk/material-ui-vite-ts/src/components/employee_ready_orders_page/OrderReadyCard.tsx
+++ b/frontend/SpringKiosk/material-ui-vite-ts/src/components/employee_ready_orders_page/OrderReadyCard.tsx
@@ -1,15 +1,28 @@
-import { Button, Card, CardActions, CardContent, Typography } from "@mui/material";
+import { Button, Card, CardActions, CardContent, Paper, Typography } from "@mui/material";
+import { CookOrder } from "../../types/OrderTypes";
 
-const OrderReadyCard = () => {
+interface OrderReadyCardProps {
+    order: CookOrder;
+}
+
+const OrderReadyCard = ({order}: OrderReadyCardProps) => {
     return (
         <Card sx={{ minWidth: 275 }}>
             <CardContent>
-                <Typography sx={{ fontSize: 30 }} color="text.secondary" gutterBottom>
-                    ORDER: 10
+                <Paper sx={{ padding: 1, backgroundColor: 'darkgreen', color: 'white', borderRadius: 1, textAlign: 'center', marginBottom: 2 }}>
+                    PRIORITY
+                </Paper>
+                <Typography sx={{ fontSize: 30, fontWeight: 'bold' }} color="text.secondary" gutterBottom>        
+                    ORDER: {order.id}
+                </Typography>
+                <Typography variant="subtitle2">
+                    <span style={{fontWeight: "bold", fontStyle:"italic"}}>Menus: </span>{order.orderMenus.map(o => o.menu.name).join(" ,")}
                 </Typography>
             </CardContent>
             <CardActions>
-                <Button size="small">Confirm Pick Up</Button>
+                <Button size="small" color="primary">
+                    Confirm Pick Up
+                </Button>
             </CardActions>
         </Card>
     )

--- a/frontend/SpringKiosk/material-ui-vite-ts/src/components/employee_ready_orders_page/OrderReadyCard.tsx
+++ b/frontend/SpringKiosk/material-ui-vite-ts/src/components/employee_ready_orders_page/OrderReadyCard.tsx
@@ -3,9 +3,10 @@ import { CookOrder } from "../../types/OrderTypes";
 
 interface OrderReadyCardProps {
     order: CookOrder;
+    updateStatusMethod: (order: CookOrder) => void;
 }
 
-const OrderReadyCard = ({order}: OrderReadyCardProps) => {
+const OrderReadyCard = ({order, updateStatusMethod}: OrderReadyCardProps) => {
     return (
         <Card sx={{ minWidth: 275 }}>
             <CardContent>
@@ -16,13 +17,16 @@ const OrderReadyCard = ({order}: OrderReadyCardProps) => {
                     <span style={{fontWeight: "bold", fontStyle:"italic"}}>Menus: </span>{order.orderMenus.map(o => o.menu.name).join(" ,")}
                 </Typography>
             </CardContent>
-            <CardActions>
-                <Button size="small" color="primary">
+            <CardActions sx={{display:"flex"}} disableSpacing>
+                <Button size="small" color="primary" onClick={() => updateStatusMethod(order)}>
                     Confirm Pick Up
                 </Button>
                 {order.priority && (
-                    <Typography ml={"auto"} mr={0} pr={1}
+                    <Typography
                         sx={{
+                            paddingRight: 1,
+                            marginLeft: "auto",
+                            marginRight: 0,
                             fontWeight: "bold",
                             background: 'linear-gradient(to top, darkgreen, green)',
                             WebkitBackgroundClip: 'text',

--- a/frontend/SpringKiosk/material-ui-vite-ts/src/components/employee_ready_orders_page/OrderReadyCard.tsx
+++ b/frontend/SpringKiosk/material-ui-vite-ts/src/components/employee_ready_orders_page/OrderReadyCard.tsx
@@ -4,41 +4,45 @@ import { CookOrder } from "../../types/OrderTypes";
 interface OrderReadyCardProps {
     order: CookOrder;
     updateStatusMethod: (order: CookOrder) => void;
+    index: number;
 }
 
-const OrderReadyCard = ({order, updateStatusMethod}: OrderReadyCardProps) => {
+const OrderReadyCard = ({order, updateStatusMethod, index}: OrderReadyCardProps) => {
     return (
-        <Card sx={{ minWidth: 275 }}>
-            <CardContent>
-                <Typography sx={{ fontSize: 30, fontWeight: 'bold' }} color="text.secondary" gutterBottom>        
-                    ORDER: {order.id}
-                </Typography>
-                <Typography variant="subtitle2">
-                    <span style={{fontWeight: "bold", fontStyle:"italic"}}>Menus: </span>{order.orderMenus.map(o => o.menu.name).join(" ,")}
-                </Typography>
-            </CardContent>
-            <CardActions sx={{display:"flex"}} disableSpacing>
-                <Button size="small" color="primary" onClick={() => updateStatusMethod(order)}>
-                    Confirm Pick Up
-                </Button>
-                {order.priority && (
-                    <Typography
-                        sx={{
-                            paddingRight: 1,
-                            marginLeft: "auto",
-                            marginRight: 0,
-                            fontWeight: "bold",
-                            background: 'linear-gradient(to top, darkgreen, green)',
-                            WebkitBackgroundClip: 'text',
-                            WebkitTextFillColor: 'transparent',
-                        }}
-                    >
-                        PRIORITY
+        <div id={`${order.priority ? "priority" : "regular"}-ready-order-${index + 1}`}>
+            <Card sx={{ minWidth: 275 }}>
+                <CardContent>
+                    <Typography sx={{ fontSize: 30, fontWeight: 'bold' }} color="text.secondary" gutterBottom>        
+                        ORDER: {order.id}
                     </Typography>
-                )}
-                
-            </CardActions>
-        </Card>
+                    <Typography variant="subtitle2">
+                        <span style={{fontWeight: "bold", fontStyle:"italic"}}>Menus: </span>{order.orderMenus.map(o => o.menu.name).join(" ,")}
+                    </Typography>
+                </CardContent>
+                <CardActions sx={{display:"flex"}} disableSpacing>
+                    <Button id={`${order.priority ? "priority" : "regular"}-ready-button-${index + 1}`} size="small" color="primary" onClick={() => updateStatusMethod(order)}>
+                        Confirm Pick Up
+                    </Button>
+                    {order.priority && (
+                        <Typography
+                            sx={{
+                                paddingRight: 1,
+                                marginLeft: "auto",
+                                marginRight: 0,
+                                fontWeight: "bold",
+                                background: 'linear-gradient(to top, darkgreen, green)',
+                                WebkitBackgroundClip: 'text',
+                                WebkitTextFillColor: 'transparent',
+                            }}
+                        >
+                            PRIORITY
+                        </Typography>
+                    )}
+                    
+                </CardActions>
+            </Card>
+        </div>
+        
     )
 }
 

--- a/frontend/SpringKiosk/material-ui-vite-ts/src/pages/EmployeeCook.tsx
+++ b/frontend/SpringKiosk/material-ui-vite-ts/src/pages/EmployeeCook.tsx
@@ -73,7 +73,7 @@ const EmployeeCook = () => {
       })
       
       enqueueSnackbar<"success">(`Successfully updated ${orderUpdate.priority ? "PRIORITY" : ""} order ${orderUpdate.orderId} to ${orderUpdate.newOrderStatus}`, 
-        {variant: "success", autoHideDuration: 1000000}
+        {variant: "success", autoHideDuration: 5000}
       );
     }
   }

--- a/frontend/SpringKiosk/material-ui-vite-ts/src/pages/EmployeeReadyToPickUp.tsx
+++ b/frontend/SpringKiosk/material-ui-vite-ts/src/pages/EmployeeReadyToPickUp.tsx
@@ -77,7 +77,7 @@ const EmployeeReadyToPickUp = () => {
       })
       
       enqueueSnackbar<"success">(`Successfully updated ${orderUpdate.priority ? "PRIORITY" : ""} order ${orderUpdate.orderId} to ${orderUpdate.newOrderStatus}`, 
-        {variant: "success", autoHideDuration: 1000000}
+        {variant: "success", autoHideDuration: 5000}
       );
     }
   }
@@ -102,6 +102,20 @@ const EmployeeReadyToPickUp = () => {
     if (newStatus === OrderStatus.READY)
       return priority ? setPriorityReadyOrders : setRegularReadyOrders;
     return undefined;
+  }
+
+  const sendOrderStatusUpdate = (order: CookOrder) => {
+    const updateBody = {
+      orderId: order.id,
+    }
+    if (websocketClient)
+      websocketClient.publish({
+          destination: "/app/order_updates", 
+          body: JSON.stringify(updateBody),
+          headers: {
+            "content-type": "application/json"
+          }
+      })
   }
 
   return (
@@ -129,12 +143,12 @@ const EmployeeReadyToPickUp = () => {
         <Grid container sx={{ width: "100%" }} spacing={2}>
           {priorityReadyOrders.map(o => (
             <Grid item md={4} key={o.id}>
-              <OrderReadyCard order={o}/>
+              <OrderReadyCard updateStatusMethod={sendOrderStatusUpdate} order={o}/>
             </Grid>
           ))}
           {regularReadyOrders.map(o => (
             <Grid item md={4} key={o.id}>
-              <OrderReadyCard order={o}/>
+              <OrderReadyCard updateStatusMethod={sendOrderStatusUpdate} order={o}/>
             </Grid>
           ))}
         </Grid>

--- a/frontend/SpringKiosk/material-ui-vite-ts/src/pages/EmployeeReadyToPickUp.tsx
+++ b/frontend/SpringKiosk/material-ui-vite-ts/src/pages/EmployeeReadyToPickUp.tsx
@@ -141,14 +141,14 @@ const EmployeeReadyToPickUp = () => {
         </Box>
       ) : (
         <Grid container sx={{ width: "100%" }} spacing={2}>
-          {priorityReadyOrders.map(o => (
+          {priorityReadyOrders.map((o, index) => (
             <Grid item md={4} key={o.id}>
-              <OrderReadyCard updateStatusMethod={sendOrderStatusUpdate} order={o}/>
+              <OrderReadyCard index={index} updateStatusMethod={sendOrderStatusUpdate} order={o}/>
             </Grid>
           ))}
-          {regularReadyOrders.map(o => (
+          {regularReadyOrders.map((o, index) => (
             <Grid item md={4} key={o.id}>
-              <OrderReadyCard updateStatusMethod={sendOrderStatusUpdate} order={o}/>
+              <OrderReadyCard index={index} updateStatusMethod={sendOrderStatusUpdate} order={o}/>
             </Grid>
           ))}
         </Grid>

--- a/frontend/SpringKiosk/material-ui-vite-ts/src/pages/EmployeeReadyToPickUp.tsx
+++ b/frontend/SpringKiosk/material-ui-vite-ts/src/pages/EmployeeReadyToPickUp.tsx
@@ -1,37 +1,145 @@
-import { Container, Grid, Typography } from "@mui/material";
+import { Box, Container, Grid, Typography } from "@mui/material";
 import OrderReadyCard from "../components/employee_ready_orders_page/OrderReadyCard";
+import { useWebSocket } from "../context/WebsocketContext";
+import { useEffect, useState } from "react";
+import { IMessage } from "@stomp/stompjs";
+import { CookOrder, OrderStatus, OrderUpdateMessage, WebsocketConnectMessage } from "../types/OrderTypes";
+import { enqueueSnackbar } from "notistack";
 
 const EmployeeReadyToPickUp = () => {
+  const { websocketClient } = useWebSocket();
+  const [regularReadyOrders, setRegularReadyOrders] = useState<CookOrder[]>([]);
+  const [priorityReadyOrders, setPriorityReadyOrders] = useState<CookOrder[]>([]);
+  const [regularIdleOrders, setRegularIdleOrders] = useState<CookOrder[]>([]);
+  const [priorityIdleOrders, setPriorityIdleOrders] = useState<CookOrder[]>([]);
+  const [regularPreparingOrders, setRegularPreparingOrders] = useState<CookOrder[]>([]);
+  const [priorityPreparingOrders, setPriorityPreparingOrders] = useState<CookOrder[]>([]);
 
+
+  useEffect(() => {
+    websocketClient?.subscribe("/user/topic/orders", (message: IMessage) => {
+      handleReceiveExistingOrders(message);
+    
+    });
+    
+    websocketClient?.subscribe("/topic/orders", (message: IMessage) => {
+      handleReceiveNewOrderOrOrderUpdate(message);
+    })
+  }, [websocketClient])
+
+  const handleReceiveExistingOrders = (message: IMessage) => {
+    const existingOrders: WebsocketConnectMessage = JSON.parse(message.body);
+    setRegularReadyOrders(existingOrders.regularReadyOrders);
+    setPriorityReadyOrders(existingOrders.priorityReadyOrders);
+    setRegularIdleOrders(existingOrders.regularIdleOrders);
+    setPriorityIdleOrders(existingOrders.priorityIdleOrders);
+    setRegularPreparingOrders(existingOrders.regularPreparingOrders);
+    setPriorityPreparingOrders(existingOrders.priorityPreparingOrders);
+  }
+
+  const handleReceiveNewOrderOrOrderUpdate = (message: IMessage) => {
+    const receivedMessage: Record<string, any> = JSON.parse(message.body);
+    if (receivedMessage.hasOwnProperty("orderMenus")) { // new order message (new orders are always in IDLE status)
+      const newOrder = receivedMessage as CookOrder;
+      if (newOrder.priority) {
+        setPriorityIdleOrders((oldState) => {
+          return [...oldState, newOrder];  
+        })
+      } else {
+        setRegularIdleOrders((oldState) => {
+          return [...oldState, newOrder];
+        })
+      }
+    } else if (receivedMessage.hasOwnProperty("newOrderStatus")) { // order update message
+      const orderUpdate = receivedMessage as OrderUpdateMessage;
+      const setOldQueue = getOldQueueSetterBasedOnNewStatusAndPriority(orderUpdate.newOrderStatus, orderUpdate.priority);
+      const setNewQueue = getNewQueueSetterBasedOnNewStatusAndPriority(orderUpdate.newOrderStatus, orderUpdate.priority);
+      let cookOrderToMove: CookOrder | undefined = undefined;
+
+      // remove this order from old queue
+      setOldQueue?.((prevState) => {
+        const updatedQueue = prevState.filter((order) => {
+          if (order.id === orderUpdate.orderId) {
+            cookOrderToMove = order;
+            return false;
+          }
+          return true;
+        });
+        return updatedQueue;
+      })
+
+      // add this order to the new queue
+      setNewQueue?.((prevState) => {
+        return [
+          ...prevState,
+          cookOrderToMove!
+        ]
+      })
+      
+      enqueueSnackbar<"success">(`Successfully updated ${orderUpdate.priority ? "PRIORITY" : ""} order ${orderUpdate.orderId} to ${orderUpdate.newOrderStatus}`, 
+        {variant: "success", autoHideDuration: 1000000}
+      );
+    }
+  }
+
+  // returns old queue setter, so that the order can be removed from the queue
+  // returns undefined if queue is not relevant to this page (cooks don't need to know when orders are picked up, for example)
+  const getOldQueueSetterBasedOnNewStatusAndPriority = (newStatus: OrderStatus, priority: boolean): React.Dispatch<React.SetStateAction<CookOrder[]>> | undefined => {
+    if (newStatus === OrderStatus.PREPARING) 
+      return priority ? setPriorityIdleOrders : setRegularIdleOrders;
+    if (newStatus === OrderStatus.READY)
+      return priority ? setPriorityPreparingOrders : setRegularPreparingOrders;
+    if (newStatus === OrderStatus.PICKED_UP)
+      return priority ? setPriorityReadyOrders : setRegularReadyOrders;
+    return undefined;
+  }
+
+  // returns new queue, so that the order can be added to the queue
+  // returns undefined if new queue is not relevant to this page (cooks don't need to know when orders are picked up, for example)
+  const getNewQueueSetterBasedOnNewStatusAndPriority = (newStatus: OrderStatus, priority: boolean): React.Dispatch<React.SetStateAction<CookOrder[]>> | undefined => {
+    if (newStatus === OrderStatus.PREPARING)
+      return priority ? setPriorityPreparingOrders : setRegularPreparingOrders;
+    if (newStatus === OrderStatus.READY)
+      return priority ? setPriorityReadyOrders : setRegularReadyOrders;
+    return undefined;
+  }
 
   return (
     <Container id="features" sx={{ py: { xs: 8, sm: 16 } }}>
       <Typography variant="h2" pb={6}>
         Orders that are <span style={{fontWeight: "bold"}}>ready to pick up</span>
       </Typography>
-      <Grid container sx={{ width: "100%" }} spacing={2}>
-        <Grid item md={4}>
-          <OrderReadyCard />
+      {regularReadyOrders.length === 0 && priorityReadyOrders.length === 0 ? (
+        <Box height={200} display={"flex"} alignItems={"center"} flexDirection={"column"}
+        gap={2} justifyContent={"center"}>
+          <Typography 
+            variant="h3"
+            sx={{
+              fontWeight: "bold",
+              background: 'linear-gradient(to right, darkgreen, lightgreen)',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+            }}
+          >
+            No orders ready for pick up!
+          </Typography>
+          <Typography variant="subtitle1">Keep waiting!</Typography>
+        </Box>
+      ) : (
+        <Grid container sx={{ width: "100%" }} spacing={2}>
+          {priorityReadyOrders.map(o => (
+            <Grid item md={4} key={o.id}>
+              <OrderReadyCard order={o}/>
+            </Grid>
+          ))}
+          {regularReadyOrders.map(o => (
+            <Grid item md={4} key={o.id}>
+              <OrderReadyCard order={o}/>
+            </Grid>
+          ))}
         </Grid>
-        <Grid item md={4}>
-          <OrderReadyCard />
-        </Grid>
-        <Grid item md={4}>
-          <OrderReadyCard />
-        </Grid>
-        <Grid item md={4}>
-          <OrderReadyCard />
-        </Grid>
-        <Grid item md={4}>
-          <OrderReadyCard />
-        </Grid>
-        <Grid item md={4}>
-          <OrderReadyCard />
-        </Grid>
-        <Grid item md={4}>
-          <OrderReadyCard />
-        </Grid>
-      </Grid>
+      )}
+      
     </Container>
   );
 };


### PR DESCRIPTION
**As** a desk employee 

**I want** to confirm and mark orders as delivered to costumers 

**So that** I can maintain accurate records of what orders are still being worked on 



**Acceptance Criteria**:

**Given** that there are orders ready to deliver

**When** I confirm that an order was delivered

**Then** I should no longer see it, as it was successfully delivered


Developer notes:
- `/employee/ready_orders` page receiving real data from backend for showing the current READY (to pick up) orders
- confirming orders were picked up working and tested
- tested with selenium